### PR TITLE
Handle already-renamed packages

### DIFF
--- a/src/package.py
+++ b/src/package.py
@@ -289,7 +289,7 @@ class Packager(object):
         Returns:
             compressed_path (pathlib.Path): path of compressed archive.
         """
-        compressed_path = Path(f"{self.refid}.tar.gz")
+        compressed_path = Path(self.tmp_dir, f"{self.refid}.tar.gz")
         with tarfile.open(str(compressed_path), "w:gz") as tar:
             tar.add(bag_dir, arcname=self.refid)
         rmtree(bag_dir)

--- a/src/package.py
+++ b/src/package.py
@@ -6,7 +6,6 @@ import traceback
 from datetime import datetime
 from pathlib import Path
 from shutil import rmtree
-from uuid import uuid4
 
 import bagit
 import boto3
@@ -27,13 +26,14 @@ logging.getLogger("bagit").setLevel(logging.ERROR)
 
 class Packager(object):
 
-    def __init__(self, region, role_arn, ssm_parameter_path, refid,
+    def __init__(self, region, role_arn, ssm_parameter_path, refid, package_id,
                  rights_ids, tmp_dir, source_bucket, destination_bucket,
                  pdf_destination_bucket, embargoed_destination_bucket,
                  embargoed_pdf_destination_bucket, sns_topic):
         self.region = region
         self.role_arn = role_arn
         self.refid = refid
+        self.package_id = package_id
         self.rights_ids = [r.strip() for r in rights_ids.split(',')]
         self.tmp_dir = tmp_dir
         self.source_bucket = source_bucket
@@ -51,10 +51,9 @@ class Packager(object):
     def run(self):
         """Main method, which calls all other methods."""
         logging.debug(
-            f'Packaging started for package {self.refid}.')
+            f'Packaging started for package {self.package_id}.')
         try:
-            bag_dir = Path(self.tmp_dir, self.refid)
-            bag_identifier = str(uuid4())
+            bag_dir = Path(self.tmp_dir, self.package_id)
             config = self.get_config(self.ssm_parameter_path)
             aquila_client = AquilaClient(config.get('AQUILA_BASEURL'))
             self.as_client = ASpace(
@@ -63,7 +62,7 @@ class Packager(object):
                 password=config.get('AS_PASSWORD')
             ).client
             self.as_repo = config.get('AS_REPO')
-            as_uri = self.uri_from_refid(bag_dir.name)
+            as_uri = self.uri_from_refid(self.refid)
             as_data = self.get_as_data(as_uri)
             rights_data = aquila_client.get_rights_data(
                 self.rights_ids, as_data)
@@ -75,14 +74,14 @@ class Packager(object):
                 compressed_path = self.compress_embargoed_bag(bag_dir)
             else:
                 bag_json = self.get_bag_json(
-                    bag_identifier, as_data['display_string'], rights_data, as_data['uri'])
+                    self.package_id, as_data['display_string'], rights_data, as_data['uri'])
                 compressed_path = self.compress_bag(
-                    bag_identifier, bag_dir, bag_json)
+                    self.package_id, bag_dir, bag_json)
             self.deliver_package(compressed_path)
             self.cleanup_successful_job()
             self.deliver_success_notification()
             logging.info(
-                f'Package {self.refid} successfully packaged.')
+                f'Package {self.package_id} successfully packaged.')
         except Exception as e:
             logging.exception(e)
             self.cleanup_failed_job(bag_dir)
@@ -134,7 +133,7 @@ class Packager(object):
         """Copies files from source bucket into temporary directory."""
         client = self.get_client_with_role('s3', self.role_arn)
         paginator = client.get_paginator('list_objects_v2')
-        for prefix in [f'{self.refid}/master', f'{self.refid}/master_edited']:
+        for prefix in [f'{self.package_id}/master', f'{self.package_id}/master_edited']:
             pages = paginator.paginate(
                 Bucket=self.source_bucket,
                 Prefix=prefix)
@@ -290,7 +289,7 @@ class Packager(object):
         Returns:
             compressed_path (pathlib.Path): path of compressed archive.
         """
-        compressed_path = Path(f"{bag_dir}.tar.gz")
+        compressed_path = Path(f"{self.refid}.tar.gz")
         with tarfile.open(str(compressed_path), "w:gz") as tar:
             tar.add(bag_dir, arcname=self.refid)
         rmtree(bag_dir)
@@ -411,20 +410,15 @@ class Packager(object):
             as_uri (str): URI for archival object in ArchivesSpace
         """
         client = self.get_client_with_role('s3', self.role_arn)
-        pdf_path = Path(self.tmp_dir, f'{self.refid}.pdf')
-        client.download_file(
-            self.source_bucket,
-            f'{self.refid}/service_edited/{self.refid}.pdf',
-            str(pdf_path))
         destination = self.embargoed_pdf_destination_bucket if self.is_embargoed else self.pdf_destination_bucket
         target_path = f'{self.refid}.pdf' if self.is_embargoed else f'pdfs/{shortuuid.uuid(as_uri)}'
-        self.upload_file(
-            destination,
-            pdf_path,
-            target_path,
-            'application/pdf',
-            self.is_embargoed)
-        pdf_path.unlink()
+        client.copy_object(
+            CopySource={
+                'Bucket': self.source_bucket,
+                'Key': f'{self.package_id}/service_edited/{self.refid}.pdf'
+            },
+            Bucket=destination,
+            Key=target_path)
         logging.debug(f'PDF delivered to {destination}.')
 
     def cleanup_successful_job(self):
@@ -433,7 +427,7 @@ class Packager(object):
         paginator = client.get_paginator('list_objects_v2')
         pages = paginator.paginate(
             Bucket=self.source_bucket,
-            Prefix=self.refid)
+            Prefix=self.package_id)
 
         objects_to_delete = []
         for page in pages:
@@ -468,11 +462,15 @@ class Packager(object):
         client = self.get_client_with_role('sns', self.role_arn)
         client.publish(
             TopicArn=self.sns_topic,
-            Message=f'Package {self.refid} successfully packaged.',
+            Message=f'Package {self.package_id} successfully packaged.',
             MessageAttributes={
                 'refid': {
                     'DataType': 'String',
                     'StringValue': self.refid,
+                },
+                'package_id': {
+                    'DataType': 'String',
+                    'StringValue': self.package_id,
                 },
                 'service': {
                     'DataType': 'String',
@@ -495,11 +493,15 @@ class Packager(object):
         tb = ''.join(traceback.format_exception(exception)[:-1])
         client.publish(
             TopicArn=self.sns_topic,
-            Message=f'Package {self.refid} failed packaging.',
+            Message=f'Package {self.package_id} failed packaging.',
             MessageAttributes={
                 'refid': {
                     'DataType': 'String',
                     'StringValue': self.refid,
+                },
+                'package_id': {
+                    'DataType': 'String',
+                    'StringValue': self.package_id,
                 },
                 'service': {
                     'DataType': 'String',
@@ -553,6 +555,7 @@ class Packager(object):
 
 if __name__ == '__main__':
     refid = os.environ.get('REFID')
+    package_id = os.environ.get('PACKAGE_ID')
     rights_ids = os.environ.get('RIGHTS_IDS')
     region = os.environ.get('AWS_REGION')
     role_arn = os.environ.get('AWS_ROLE_ARN')
@@ -572,6 +575,7 @@ if __name__ == '__main__':
         role_arn,
         ssm_parameter_path,
         refid,
+        package_id,
         rights_ids,
         tmp_dir,
         source_bucket,

--- a/src/package.py
+++ b/src/package.py
@@ -410,15 +410,20 @@ class Packager(object):
             as_uri (str): URI for archival object in ArchivesSpace
         """
         client = self.get_client_with_role('s3', self.role_arn)
+        pdf_path = Path(self.tmp_dir, f'{self.package_id}.pdf')
+        client.download_file(
+            self.source_bucket,
+            f'{self.package_id}/service_edited/{self.refid}.pdf',
+            str(pdf_path))
         destination = self.embargoed_pdf_destination_bucket if self.is_embargoed else self.pdf_destination_bucket
         target_path = f'{self.refid}.pdf' if self.is_embargoed else f'pdfs/{shortuuid.uuid(as_uri)}'
-        client.copy_object(
-            CopySource={
-                'Bucket': self.source_bucket,
-                'Key': f'{self.package_id}/service_edited/{self.refid}.pdf'
-            },
-            Bucket=destination,
-            Key=target_path)
+        self.upload_file(
+            destination,
+            pdf_path,
+            target_path,
+            'application/pdf',
+            self.is_embargoed)
+        pdf_path.unlink()
         logging.debug(f'PDF delivered to {destination}.')
 
     def cleanup_successful_job(self):

--- a/src/package.py
+++ b/src/package.py
@@ -310,25 +310,33 @@ class Packager(object):
         Returns:
             compressed_path (pathlib.Path): path of compressed archive.
         """
-        root_dir = Path(self.tmp_dir, bag_identifier)
-        outer_compressed_path = Path(self.tmp_dir, f"{bag_identifier}.tar.gz")
-        inner_compressed_path = root_dir / f"{bag_identifier}.tar.gz"
-        root_dir.mkdir()
-        with tarfile.open(str(inner_compressed_path), "w:gz") as tar:
+        compressed_path = Path(self.tmp_dir, f"{bag_identifier}.tar.gz")
+
+        """Compress bag contents"""
+        with tarfile.open(str(compressed_path), "w:gz") as tar:
             tar.add(bag_dir, arcname=bag_identifier)
-        with open(Path(root_dir, f"{bag_identifier}.json"), "w") as json_file:
+
+        """Empty out root directory"""
+        rmtree(bag_dir)
+        bag_dir.mkdir()
+
+        """Add contents to empty root directory"""
+        compressed_path.rename(Path(bag_dir, f"{bag_identifier}.tar.gz"))
+        with open(Path(bag_dir, f"{bag_identifier}.json"), "w") as json_file:
             json.dump(
                 bag_json,
                 json_file,
                 indent=4,
                 sort_keys=True,
                 default=str)
-        with tarfile.open(str(outer_compressed_path), "w:gz") as tar:
-            tar.add(root_dir, arcname=bag_identifier)
+
+        """Compress root directory"""
+        with tarfile.open(str(compressed_path), "w:gz") as tar:
+            tar.add(bag_dir, arcname=bag_identifier)
+
         rmtree(bag_dir)
-        rmtree(root_dir)
-        logging.debug(f'Compressed bag {outer_compressed_path} created.')
-        return outer_compressed_path
+        logging.debug(f'Compressed bag {compressed_path} created.')
+        return compressed_path
 
     def upload_file(self, bucket, source_file_path,
                     destination_path, content_type, increment_if_exists):

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -19,6 +19,7 @@ ARGS = ['us-east-1',
         'digitized-image-packaging-role-arn',
         '/dev/digitized_image_packaging',
         'b90862f3baceaae3b7418c78f9d50d52',
+        '956b9082-e753-42f4-b354-d6f48231ea7b',
         '1,2',
         'tmp',
         'source_bucket',
@@ -86,7 +87,7 @@ def test_run(mock_notification, mock_cleanup, mock_pdf, mock_deliver, mock_compr
              mock_move, mock_has_embargo, mock_rights_data, mock_as_data, mock_as_uri, mock_aquila, mock_config):
     """Asserts run method calls other methods."""
     packager = Packager(*ARGS)
-    bag_dir = Path(packager.tmp_dir, packager.refid)
+    bag_dir = Path(packager.tmp_dir, packager.package_id)
     aquila_baseurl = 'https://aquila.rockarch.org/api/'
     mock_aquila.return_value = None
     config = {'AQUILA_BASEURL': aquila_baseurl}
@@ -133,7 +134,7 @@ def test_run_with_exception(
     mock_as_uri.side_effect = exception
     packager.run()
     mock_cleanup.assert_called_once_with(
-        Path(packager.tmp_dir, packager.refid))
+        Path(packager.tmp_dir, packager.package_id))
     mock_notification.assert_called_once_with(exception)
     mock_config.assert_called_once_with(packager.ssm_parameter_path)
 
@@ -203,7 +204,7 @@ def test_get_active_rights_acts():
 def test_move_to_tmp():
     """Asserts packages are moved to temp directory as expected."""
     packager = Packager(*ARGS)
-    tmp_path = Path(packager.tmp_dir, packager.refid)
+    tmp_path = Path(packager.tmp_dir, packager.package_id)
     client = boto3.client('s3')
     client.create_bucket(Bucket=packager.source_bucket)
     fixture_path = Path('tests', 'fixtures', packager.refid)
@@ -211,7 +212,7 @@ def test_move_to_tmp():
         for f in files:
             source = dirpath / f
             destination = Path(
-                packager.refid,
+                packager.package_id,
                 source.relative_to(fixture_path))
             client.upload_file(
                 str(source),
@@ -259,7 +260,7 @@ def test_create_bag():
     assert bag.info['ArchivesSpace-URI'] == '/repositories/2/archival_objects/1234'
     assert bag.info['Start-Date'] == '1999-01-01'
     assert bag.info['End-Date'] == '2000-12-31'
-    assert bag.info['Rights-ID'] == ARGS[4].split(',')
+    assert bag.info['Rights-ID'] == packager.rights_ids
     assert bag.info['Title'] == 'foobar'
     assert bag.info['BagIt-Profile-Identifier'] == 'zorya_bagit_profile.json'
 
@@ -355,7 +356,7 @@ def test_compress_bag():
 def test_compress_embargoed_bag():
     packager = Packager(*ARGS)
     fixture_path = Path('tests', 'fixtures', packager.refid)
-    tmp_path = Path(packager.tmp_dir, packager.refid)
+    tmp_path = Path(packager.tmp_dir, packager.package_id)
     copytree(fixture_path, tmp_path)
     bagit.make_bag(tmp_path)
 
@@ -450,7 +451,7 @@ def test_deliver_pdf():
         for f in files:
             source = dirpath / f
             destination = Path(
-                packager.refid,
+                packager.package_id,
                 source.relative_to(fixture_path))
             client.upload_file(
                 str(source),
@@ -458,8 +459,7 @@ def test_deliver_pdf():
                 str(destination))
 
     for is_embargoed, destination_bucket, destination_key in [
-            (False, packager.pdf_destination_bucket,
-             f'pdfs/{shortuuid.uuid(as_uri)}'),
+            (False, packager.pdf_destination_bucket, f'pdfs/{shortuuid.uuid(as_uri)}'),
             (True, packager.embargoed_pdf_destination_bucket, f'{packager.refid}.pdf')]:
         with mock_aws():
             packager.is_embargoed = is_embargoed
@@ -487,7 +487,7 @@ def test_cleanup_successful_job():
         for f in files:
             source = dirpath / f
             destination = Path(
-                packager.refid,
+                packager.package_id,
                 source.relative_to(fixture_path))
             client.upload_file(
                 str(source),
@@ -498,7 +498,7 @@ def test_cleanup_successful_job():
 
     object_count = client.list_objects_v2(
         Bucket=packager.source_bucket,
-        Prefix=packager.refid)['KeyCount']
+        Prefix=packager.package_id)['KeyCount']
 
     assert object_count == 0
 
@@ -549,6 +549,7 @@ def test_deliver_success_notification(mock_role):
     message_body = json.loads(messages[0].body)
     assert message_body['MessageAttributes']['outcome']['Value'] == 'SUCCESS'
     assert message_body['MessageAttributes']['refid']['Value'] == packager.refid
+    assert message_body['MessageAttributes']['package_id']['Value'] == packager.package_id
 
 
 @mock_aws
@@ -580,5 +581,6 @@ def test_deliver_failure_notification(mock_traceback, mock_role):
     message_body = json.loads(messages[0].body)
     assert message_body['MessageAttributes']['outcome']['Value'] == 'FAILURE'
     assert message_body['MessageAttributes']['refid']['Value'] == packager.refid
+    assert message_body['MessageAttributes']['package_id']['Value'] == packager.package_id
     assert exception_message in message_body['MessageAttributes']['message']['Value']
     assert message_body['MessageAttributes']['traceback']['Value'] == 'baz'

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -343,12 +343,11 @@ def test_compress_bag():
     """Asserts compressed files are correctly created and original directory is removed."""
     packager = Packager(*ARGS)
     fixture_path = Path('tests', 'fixtures', packager.refid)
-    tmp_path = Path(packager.tmp_dir, packager.refid)
+    tmp_path = Path(packager.tmp_dir, packager.package_id)
     copytree(fixture_path, tmp_path)
     bagit.make_bag(tmp_path)
-    bag_identifier = "123456789"
 
-    compressed = packager.compress_bag(bag_identifier, tmp_path, {})
+    compressed = packager.compress_bag(packager.package_id, tmp_path, {})
     assert compressed.is_file()
     assert not tmp_path.exists()
 


### PR DESCRIPTION
Packages are now renamed earlier in the pipeline, so renaming is no longer needed. Renames embargo packages using refids.